### PR TITLE
chore: drop usage of npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ A simple template to help you quickly build the mcbe module development environm
 git clone https://github.com/mcbe-mods/quick-start.git
 cd quick-start
 
+# If you don't have pnpm installed...
+corepack enable
+
 # Install dependencies
 pnpm install
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ git clone https://github.com/mcbe-mods/quick-start.git
 cd quick-start
 
 # Install dependencies
-## If you don't have pnpm, use the `npm install` command to install it.
 pnpm install
 
 # Building

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ cd quick-start
 pnpm install
 
 # Building
-npm run build
+pnpm run build
 
 # dev: Automatically builds when file changes are found
-npm run dev
+pnpm run dev
 
-# dev: Same as `npm run dev`, but with a new feature that automatically writes to the game directory (/Packages/Microsoft.MinecraftUWP_8wekyb3d8bbwe/LocalState/games/com.mojang), namely _dev_behavior_pack and _dev_resource_pack
-npm run dev game
+# dev: Same as `pnpm run dev`, but with a new feature that automatically writes to the game directory (/Packages/Microsoft.MinecraftUWP_8wekyb3d8bbwe/LocalState/games/com.mojang), namely _dev_behavior_pack and _dev_resource_pack
+pnpm run dev game
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "quick-start",
   "private": true,
+  "packageManager": "pnpm@8.6.11",
   "version": "0.0.0",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "copy": "node scripts/copy.js",
     "package": "node scripts/package.js",
     "prebuild": "node scripts/build.js",
-    "build": "npm run clear && npm run copy && tsc && npm run prebuild && npm run package",
+    "build": "pnpm run clear && pnpm run copy && tsc && pnpm run prebuild && pnpm run package",
     "lint": "eslint src && prettier --check src",
     "lint:fix": "eslint --fix src && prettier --check --write src"
   },


### PR DESCRIPTION
I would suggest not recommending using npm to install dependencies when pnpm is not installed too. That would cause some problems. Developers can simply run `corepack enable` if you have defined `packageManager` field in your `package.json`.